### PR TITLE
Change sqlalchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 future
 emoji
 requests
-sqlalchemy
+sqlalchemy==1.3.20
 python-telegram-bot==11.1.0
 psycopg2-binary
 feedparser


### PR DESCRIPTION
For avoiding `sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres`